### PR TITLE
Spelling: e-mail address

### DIFF
--- a/wllegal/templates/legal/documents/privacy.html
+++ b/wllegal/templates/legal/documents/privacy.html
@@ -22,7 +22,7 @@
 
 <dl>
 
-<dt>{% trans "Name and e-mail" %}</dt>
+<dt>{% trans "Name and e-mail address" %}</dt>
 <dd>{% trans "These are used to identify you in the VCS commits" %}</dd>
 <dd>{% trans "Additionally, e-mail is used for notification of watched events" %}</dd>
 


### PR DESCRIPTION
As distinctly different from "e-mail" being used "for notification of watched events"