### PR TITLE
Spelling: Info, collecting invoice info, ending dots

### DIFF
--- a/wllegal/templates/legal/documents/privacy.html
+++ b/wllegal/templates/legal/documents/privacy.html
@@ -23,18 +23,18 @@
 <dl>
 
 <dt>{% trans "Name and e-mail address" %}</dt>
-<dd>{% trans "These are used to identify you in the VCS commits" %}</dd>
-<dd>{% trans "Additionally, e-mail is used for notification of watched events" %}</dd>
+<dd>{% trans "These are used to identify you in the VCS commits." %}</dd>
+<dd>{% trans "Additionally, e-mail is used for notification of watched events." %}</dd>
 
 <dt>{% trans "Password in hashed form" %}</dt>
 <dd>{% trans "Used to authenticate the User, if configured" %}</dd>
 <dd>{% trans "Passwords are stored hashed using Argon2." %}</dd>
 
 <dt>{% trans "IP address and browser name" %}</dt>
-<dd>{% trans "These are logged in case of important changes to your account (e.g. password change) to allow diagnosis in case your account is stolen" %}</dd>
+<dd>{% trans "These are logged in case of important changes to your account (e.g. password change) to allow diagnosis in case your account is stolen." %}</dd>
 
-<dt>{% trans "Billing information" %}</dt>
-<dd>{% trans "In case you purchase service from us, we collect additional billing information necessary for issuing an invoice" %}</dd>
+<dt>{% trans "Billing info" %}</dt>
+<dd>{% trans "Necessary details to issue an invoice is collected when purchasing a service from us." %}</dd>
 
 </dl>
 
@@ -66,7 +66,7 @@
 
 <p>{% blocktrans %}The Personal Data is stored in the Service until the User deletes their account on the service.{% endblocktrans %}</p>
 
-<p>{% blocktrans %}Access log information might be collected for a longer period for the purpose of establishing, exercising or defending legal claims.{% endblocktrans %}</p>
+<p>{% blocktrans %}Access log info might be collected for a longer period for the purpose of establishing, exercising or defending legal claims.{% endblocktrans %}</p>
 
 <h2 id="rights">{% blocktrans %}Your rights{% endblocktrans %}</h2>
 


### PR DESCRIPTION
Mitigation for ending up out of bounds in https://weblate.org/nb/payment/37bd88ca-b301-4631-a6bf-2c981c93939b/
with "billing info"

![bilde](https://user-images.githubusercontent.com/13802408/159106180-f61e9589-3661-479c-a54e-2c56c33a7f24.png)

Should also be limited to ~21 characters in https://hosted.weblate.org/translate/weblate/legal/nb_NO/?checksum=aa8b8f77f0f11aed